### PR TITLE
Add safe symmetric cipher API

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -15,6 +15,9 @@ macro_rules! tryt {
 }
 
 
+pub type Result<T> = ::std::result::Result<T, Error>;
+
+
 #[derive(Debug, Fail)]
 pub enum Error {
     #[fail(display = "{}", _0)]

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -1,8 +1,8 @@
+use error::Result;
 use ffi;
 use std::ffi::{CStr, CString};
 use std::mem;
 use std::os::raw::*;
-use super::Result;
 
 
 /// A cryptographic hash algorithm.

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -1,0 +1,8 @@
+//! Internal helper functions used by other modules.
+
+/// Allocate an uninitialized byte vector of a given size.
+pub unsafe fn alloc(size: usize) -> Vec<u8> {
+    let mut vec = Vec::with_capacity(size);
+    vec.set_len(size);
+    vec
+}

--- a/src/symmetric.rs
+++ b/src/symmetric.rs
@@ -1,0 +1,405 @@
+//! Provides symmetric block cipher algorithms and cipher modes.
+//!
+//! LibTomCrypt provides several block ciphers with an ECB block mode interface. It is important to first note that you
+//! should never use the ECB modes directly to encrypt data. Instead you should use the ECB functions to make a chaining
+//! mode, or use one of the provided chaining modes.
+use error::{Error, Result};
+use ffi;
+use internal;
+use std::ffi::{CStr, CString};
+use std::mem;
+use std::os::raw::*;
+use std::slice;
+
+
+/// A symmetric encryption cipher.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Cipher(c_int);
+
+impl Cipher {
+    /// Find a cipher algorithm by name.
+    pub fn find(name: &str) -> Option<Self> {
+        ::init();
+
+        unsafe {
+            let name = CString::new(name).unwrap();
+
+            match ffi::find_cipher(name.as_ptr()) {
+                -1 => None,
+                index => Some(Cipher(index)),
+            }
+        }
+    }
+
+    /// Get a cipher algorithm by name. Panics if the algorithm is not available.
+    fn find_required(name: &str) -> Self {
+        match Self::find(name) {
+            Some(hash) => hash,
+            None => panic!("{} algorithm not available", name),
+        }
+    }
+
+    /// Get the AES cipher algorithm.
+    ///
+    /// This cipher is also known as Rijndael.
+    pub fn aes() -> Self {
+        Cipher::find_required("aes")
+    }
+
+    /// Get the name of this cipher.
+    pub fn name(&self) -> &str {
+        unsafe {
+            CStr::from_ptr(self.descriptor().name).to_str().unwrap()
+        }
+    }
+
+    /// Get the default number of rounds for this cipher.
+    pub fn default_rounds(&self) -> u32 {
+        self.descriptor().default_rounds as u32
+    }
+
+    /// Get the minimum allowed key size for this cipher.
+    pub fn min_key_length(&self) -> usize {
+        self.descriptor().min_key_length as usize
+    }
+
+    /// Get the maximum allowed key size for this cipher.
+    pub fn max_key_length(&self) -> usize {
+        self.descriptor().max_key_length as usize
+    }
+
+    /// Get the block size (in octets) for this cipher.
+    pub fn block_size(&self) -> usize {
+        self.descriptor().block_length as usize
+    }
+
+    #[inline]
+    pub(crate) fn index(&self) -> c_int {
+        self.0
+    }
+
+    #[inline]
+    fn descriptor(&self) -> &'static ffi::ltc_cipher_descriptor {
+        unsafe {
+            &*(&ffi::cipher_descriptor as *const ffi::ltc_cipher_descriptor).offset(self.0 as isize)
+        }
+    }
+}
+
+
+/// A block cipher mode of operation.
+pub trait CipherMode {
+    /// Encrypt the given plaintext and return the ciphertext.
+    fn encrypt(&mut self, plaintext: &[u8]) -> Result<Vec<u8>> {
+        unsafe {
+            let mut ciphertext = internal::alloc(plaintext.len());
+            self.encrypt_unchecked(plaintext, &mut ciphertext)?;
+
+            Ok(ciphertext)
+        }
+    }
+
+    /// Decrypt the given ciphertext and return the plaintext.
+    fn decrypt(&mut self, ciphertext: &[u8]) -> Result<Vec<u8>> {
+        unsafe {
+            let mut plaintext = internal::alloc(ciphertext.len());
+            self.decrypt_unchecked(ciphertext, &mut plaintext)?;
+
+            Ok(plaintext)
+        }
+    }
+
+    /// Encrypt the given plaintext in place.
+    fn encrypt_in_place(&mut self, buffer: &mut [u8]) -> Result<()> {
+        unsafe {
+            let ciphertext = slice::from_raw_parts_mut(buffer.as_mut_ptr(), buffer.len());
+            self.encrypt_unchecked(buffer, ciphertext)
+        }
+    }
+
+    /// Decrypt the given ciphertext in place.
+    fn decrypt_in_place(&mut self, buffer: &mut [u8]) -> Result<()> {
+        unsafe {
+            let plaintext = slice::from_raw_parts_mut(buffer.as_mut_ptr(), buffer.len());
+            self.decrypt_unchecked(buffer, plaintext)
+        }
+    }
+
+    /// Encrypt the given plaintext and write the ciphertext to the given array.
+    ///
+    /// This method is unsafe because it is up to the caller to guarantee that the given arrays are of the same length.
+    /// It is possible that the input and output buffer are the same buffer.
+    unsafe fn encrypt_unchecked(&mut self, plaintext: &[u8], ciphertext: &mut [u8]) -> Result<()>;
+
+    /// Decrypt the given ciphertext and write the plaintext to the given array.
+    ///
+    /// This method is unsafe because it is up to the caller to guarantee that the given arrays are of the same length.
+    /// It is possible that the input and output buffer are the same buffer.
+    unsafe fn decrypt_unchecked(&mut self, ciphertext: &[u8], plaintext: &mut [u8]) -> Result<()>;
+}
+
+
+/// ECB or Electronic Codebook Mode is the simplest method to use.
+///
+/// This mode is very weak since it allows people to swap blocks and perform replay attacks if the same key is used more
+/// than once.
+pub struct ECB(ffi::symmetric_ECB);
+
+impl ECB {
+    pub fn new(cipher: Cipher, key: &[u8], rounds: Option<u32>) -> Result<Self> {
+        unsafe {
+            let mut raw = mem::uninitialized();
+            tryt!(ffi::ecb_start(cipher.index(), key.as_ptr(), key.len() as c_int, rounds.unwrap_or(0) as c_int, &mut raw));
+
+            Ok(ECB(raw))
+        }
+    }
+}
+
+impl CipherMode for ECB {
+    unsafe fn encrypt_unchecked(&mut self, plaintext: &[u8], ciphertext: &mut [u8]) -> Result<()> {
+        tryt!(ffi::ecb_encrypt(plaintext.as_ptr(), ciphertext.as_mut_ptr(), plaintext.len() as u64, &mut self.0));
+
+        Ok(())
+    }
+
+    unsafe fn decrypt_unchecked(&mut self, ciphertext: &[u8], plaintext: &mut [u8]) -> Result<()> {
+        tryt!(ffi::ecb_decrypt(ciphertext.as_ptr(), plaintext.as_mut_ptr(), ciphertext.len() as u64, &mut self.0));
+
+        Ok(())
+    }
+}
+
+impl Drop for ECB {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::ecb_done(&mut self.0);
+        }
+    }
+}
+
+
+/// CBC or Cipher Block Chaining mode is a simple mode designed to prevent trivial forms of replay and swap attacks on
+/// ciphers.
+///
+/// It is important that the initialization vector be unique and preferably random for each message encrypted under the
+/// same key.
+pub struct CBC(ffi::symmetric_CBC);
+
+impl CBC {
+    pub fn new(cipher: Cipher, iv: &[u8], key: &[u8], rounds: Option<u32>) -> Result<Self> {
+        // Validate the IV size since LibTomCrypt doesn't.
+        if iv.len() != cipher.block_size() {
+            return Err(Error::from_code(ffi::CRYPT_INVALID_ARG));
+        }
+
+        unsafe {
+            let mut raw = mem::uninitialized();
+            tryt!(ffi::cbc_start(cipher.index(), iv.as_ptr(), key.as_ptr(), key.len() as c_int, rounds.unwrap_or(0) as c_int, &mut raw));
+
+            Ok(CBC(raw))
+        }
+    }
+}
+
+impl CipherMode for CBC {
+    unsafe fn encrypt_unchecked(&mut self, plaintext: &[u8], ciphertext: &mut [u8]) -> Result<()> {
+        tryt!(ffi::cbc_encrypt(plaintext.as_ptr(), ciphertext.as_mut_ptr(), plaintext.len() as u64, &mut self.0));
+
+        Ok(())
+    }
+
+    unsafe fn decrypt_unchecked(&mut self, ciphertext: &[u8], plaintext: &mut [u8]) -> Result<()> {
+        tryt!(ffi::cbc_decrypt(ciphertext.as_ptr(), plaintext.as_mut_ptr(), ciphertext.len() as u64, &mut self.0));
+
+        Ok(())
+    }
+}
+
+impl Drop for CBC {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::cbc_done(&mut self.0);
+        }
+    }
+}
+
+
+/// CTR or Counter Mode is a mode which only uses the encryption function of the cipher.
+///
+/// As long as the initialization vector is random for each message encrypted under the same key replay and swap attacks
+/// are infeasible. CTR mode may look simple but it is as secure as the block cipher is under a chosen plaintext attack
+/// (provided the initialization vector is unique).
+pub struct CTR(ffi::symmetric_CTR);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CTRCounterMode {
+    BigEndian,
+    LittleEndian,
+}
+
+impl CTR {
+    pub fn new(cipher: Cipher, iv: &[u8], key: &[u8], rounds: Option<u32>, mode: CTRCounterMode) -> Result<Self> {
+        let ctr_flags = iv.len() as c_int | match mode {
+            CTRCounterMode::BigEndian => ffi::CTR_COUNTER_BIG_ENDIAN,
+            CTRCounterMode::LittleEndian => ffi::CTR_COUNTER_LITTLE_ENDIAN,
+        } as c_int;
+
+        unsafe {
+            let mut raw = mem::uninitialized();
+
+            tryt!(ffi::ctr_start(
+                cipher.index(),
+                iv.as_ptr(),
+                key.as_ptr(),
+                key.len() as c_int,
+                rounds.unwrap_or(0) as c_int,
+                ctr_flags,
+                &mut raw,
+            ));
+
+            Ok(CTR(raw))
+        }
+    }
+}
+
+impl CipherMode for CTR {
+    unsafe fn encrypt_unchecked(&mut self, plaintext: &[u8], ciphertext: &mut [u8]) -> Result<()> {
+        tryt!(ffi::ctr_encrypt(plaintext.as_ptr(), ciphertext.as_mut_ptr(), plaintext.len() as u64, &mut self.0));
+
+        Ok(())
+    }
+
+    unsafe fn decrypt_unchecked(&mut self, ciphertext: &[u8], plaintext: &mut [u8]) -> Result<()> {
+        tryt!(ffi::ctr_decrypt(ciphertext.as_ptr(), plaintext.as_mut_ptr(), ciphertext.len() as u64, &mut self.0));
+
+        Ok(())
+    }
+}
+
+impl Drop for CTR {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::ctr_done(&mut self.0);
+        }
+    }
+}
+
+
+/// CFB or Ciphertext Feedback Mode is a mode akin to CBC.
+pub struct CFB(ffi::symmetric_CFB);
+
+impl CFB {
+    pub fn new(cipher: Cipher, iv: &[u8], key: &[u8], rounds: Option<u32>) -> Result<Self> {
+        unsafe {
+            let mut raw = mem::uninitialized();
+            tryt!(ffi::cfb_start(
+                cipher.index(),
+                iv.as_ptr(),
+                key.as_ptr(),
+                key.len() as c_int,
+                rounds.unwrap_or(0) as c_int,
+                &mut raw,
+            ));
+
+            Ok(CFB(raw))
+        }
+    }
+}
+
+impl CipherMode for CFB {
+    unsafe fn encrypt_unchecked(&mut self, plaintext: &[u8], ciphertext: &mut [u8]) -> Result<()> {
+        tryt!(ffi::cfb_encrypt(plaintext.as_ptr(), ciphertext.as_mut_ptr(), plaintext.len() as u64, &mut self.0));
+
+        Ok(())
+    }
+
+    unsafe fn decrypt_unchecked(&mut self, ciphertext: &[u8], plaintext: &mut [u8]) -> Result<()> {
+        tryt!(ffi::cfb_decrypt(ciphertext.as_ptr(), plaintext.as_mut_ptr(), ciphertext.len() as u64, &mut self.0));
+
+        Ok(())
+    }
+}
+
+impl Drop for CFB {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::cfb_done(&mut self.0);
+        }
+    }
+}
+
+
+/// OFB or Output Feedback Mode is a mode akin to CBC as well.
+pub struct OFB(ffi::symmetric_OFB);
+
+impl OFB {
+    pub fn new(cipher: Cipher, iv: &[u8], key: &[u8], rounds: Option<u32>) -> Result<Self> {
+        unsafe {
+            let mut raw = mem::uninitialized();
+
+            tryt!(ffi::ofb_start(
+                cipher.index(),
+                iv.as_ptr(),
+                key.as_ptr(), key.len() as c_int,
+                rounds.unwrap_or(0) as c_int,
+                &mut raw,
+            ));
+
+            Ok(OFB(raw))
+        }
+    }
+}
+
+impl CipherMode for OFB {
+    unsafe fn encrypt_unchecked(&mut self, plaintext: &[u8], ciphertext: &mut [u8]) -> Result<()> {
+        tryt!(ffi::ofb_encrypt(plaintext.as_ptr(), ciphertext.as_mut_ptr(), plaintext.len() as u64, &mut self.0));
+
+        Ok(())
+    }
+
+    unsafe fn decrypt_unchecked(&mut self, ciphertext: &[u8], plaintext: &mut [u8]) -> Result<()> {
+        tryt!(ffi::ofb_decrypt(ciphertext.as_ptr(), plaintext.as_mut_ptr(), ciphertext.len() as u64, &mut self.0));
+
+        Ok(())
+    }
+}
+
+impl Drop for OFB {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::ofb_done(&mut self.0);
+        }
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+
+    #[test]
+    fn test_find_cipher() {
+        assert_eq!(Cipher::find("aes").unwrap(), Cipher::aes());
+
+        for name in &["aes", "des", "blowfish"] {
+            let cipher = Cipher::find(name).unwrap();
+            assert_eq!(cipher.name(), *name);
+        }
+    }
+
+    #[test]
+    fn aes_ecb_simple() {
+        let key = [1; 16];
+        let data = vec![2; Cipher::aes().block_size()];
+        let mut buffer = data.clone();
+
+        let mut ecb = ECB::new(Cipher::aes(), key.as_ref(), None).unwrap();
+
+        ecb.encrypt_in_place(&mut buffer).unwrap();
+        ecb.decrypt_in_place(&mut buffer).unwrap();
+
+        assert_eq!(buffer, data);
+    }
+}

--- a/src/symmetric.rs
+++ b/src/symmetric.rs
@@ -233,16 +233,16 @@ impl Drop for CBC {
 pub struct CTR(ffi::symmetric_CTR);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum CTRCounterMode {
+pub enum CTREndianness {
     BigEndian,
     LittleEndian,
 }
 
 impl CTR {
-    pub fn new(cipher: Cipher, iv: &[u8], key: &[u8], rounds: Option<u32>, mode: CTRCounterMode) -> Result<Self> {
+    pub fn new(cipher: Cipher, iv: &[u8], key: &[u8], rounds: Option<u32>, mode: CTREndianness) -> Result<Self> {
         let ctr_flags = iv.len() as c_int | match mode {
-            CTRCounterMode::BigEndian => ffi::CTR_COUNTER_BIG_ENDIAN,
-            CTRCounterMode::LittleEndian => ffi::CTR_COUNTER_LITTLE_ENDIAN,
+            CTREndianness::BigEndian => ffi::CTR_COUNTER_BIG_ENDIAN,
+            CTREndianness::LittleEndian => ffi::CTR_COUNTER_LITTLE_ENDIAN,
         } as c_int;
 
         unsafe {


### PR DESCRIPTION
Add a new module, `symmetric`, which provides an API for accessing symmetric cipher algorithms and performing encryption and decryption in various block cipher modes.

The `CipherMode` trait may need some tweaking. Encrypt/decrypt methods are a bit more general and could apply to AEAD and other things. Perhaps it should be moved out of the `symmetric` module.